### PR TITLE
chore(semantic): update branches away to include main

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,14 @@
     }
   },
   "release": {
+    "branches": [
+      "+([0-9])?(.{+([0-9]),x}).x",
+      "main",
+      "next",
+      "next-major",
+      { "name": "beta", "prerelease": true },
+      { "name": "alpha", "prerelease": true }
+    ],
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
@@ -66,7 +74,6 @@
       "@semantic-release/npm",
       "@semantic-release/git",
       "@semantic-release/github"
-    ],
-    "branch": "main"
+    ]
   }
 }


### PR DESCRIPTION
This overrides semantic-release to use `main` instead of `master`. For context https://github.com/semantic-release/semantic-release/issues/1581